### PR TITLE
Wait 80% of expiry time before refresh

### DIFF
--- a/lib/amazonka/src/Amazonka/Auth/Background.hs
+++ b/lib/amazonka/src/Amazonka/Auth/Background.hs
@@ -68,4 +68,4 @@ fetchAuthInBackground menv =
 
     diff (Time x) y = (* 1000000) $ if n > 0 then n else 1
       where
-        n = truncate (Time.diffUTCTime x y) - 60
+        n = truncate (0.80 * Time.diffUTCTime x y)


### PR DESCRIPTION
This PR changes the waiting time until a token refresh is attempted to 80% of `ttl` (was `ttl` - 60 seconds before) where `ttl` is the time until the STS token expires. 